### PR TITLE
Fixed VM#path

### DIFF
--- a/lib/vixen/model/vm.rb
+++ b/lib/vixen/model/vm.rb
@@ -8,7 +8,7 @@ class Vixen::Model::VM < Vixen::Model::Base
   end
 
   def path
-    get_string_property Vixen::Constants::VixPropertyId[:vmx_pathname]
+    get_string_property Vixen::Constants::VixPropertyId[:vm_vmx_pathname]
   end
 
   def guest_os


### PR DESCRIPTION
Path wasn't working. Changed :vmx_pathname to :vm_vmx_pathname to match what was in Vixen::Constants::VixPropertyId
